### PR TITLE
Catch NuGet Push 409 status

### DIFF
--- a/Photon.Agent/Properties/AssemblyInfo.cs
+++ b/Photon.Agent/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.58")]
-[assembly: AssemblyFileVersion("0.0.58")]
+[assembly: AssemblyVersion("0.0.59")]
+[assembly: AssemblyFileVersion("0.0.59")]

--- a/Photon.Agent/Properties/AssemblyInfo.cs
+++ b/Photon.Agent/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.57")]
-[assembly: AssemblyFileVersion("0.0.57")]
+[assembly: AssemblyVersion("0.0.58")]
+[assembly: AssemblyFileVersion("0.0.58")]

--- a/Photon.Communication/MessageHandle.cs
+++ b/Photon.Communication/MessageHandle.cs
@@ -23,6 +23,7 @@ namespace Photon.Communication
         public async Task<IResponseMessage> GetResponseAsync(CancellationToken token)
         {
             token.Register(() => completionEvent.SetCanceled());
+
             var response = await completionEvent.Task;
 
             if (!(response?.Successful ?? false))

--- a/Photon.Communication/Packets/PacketSender.cs
+++ b/Photon.Communication/Packets/PacketSender.cs
@@ -40,7 +40,8 @@ namespace Photon.Communication.Packets
 
         public void Dispose()
         {
-            tokenSource?.Cancel();
+            //try {tokenSource?.Cancel();}
+            //catch {}
 
             foreach (var packetSource in packetSourceList)
                 packetSource.Dispose();

--- a/Photon.Library/GitHub/CommitStatusUpdater.cs
+++ b/Photon.Library/GitHub/CommitStatusUpdater.cs
@@ -18,6 +18,19 @@ namespace Photon.Library.GitHub
 
         public async Task<CommitStatusResponse> Post(CommitStatus status)
         {
+            try {
+                return await PostMessage(status);
+            }
+            catch (WebException error) when (error.Response is HttpWebResponse response) {
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                    throw new ApplicationException($"Status API was not found! [{StatusUrl}]");
+
+                throw;
+            }
+        }
+
+        private async Task<CommitStatusResponse> PostMessage(CommitStatus status)
+        {
             var data = status.ToJson();
             var buffer = Encoding.UTF8.GetBytes(data);
             //var url = NetPath.Combine(StatusUrl, Sha);

--- a/Photon.Server/Properties/AssemblyInfo.cs
+++ b/Photon.Server/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.57")]
-[assembly: AssemblyFileVersion("0.0.57")]
+[assembly: AssemblyVersion("0.0.58")]
+[assembly: AssemblyFileVersion("0.0.58")]
 
 [assembly: AssemblyTitle("Photon Server")]
 [assembly: AssemblyDescription("Primary service for Photon.")]

--- a/Photon.Server/Properties/AssemblyInfo.cs
+++ b/Photon.Server/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.58")]
-[assembly: AssemblyFileVersion("0.0.58")]
+[assembly: AssemblyVersion("0.0.59")]
+[assembly: AssemblyFileVersion("0.0.59")]
 
 [assembly: AssemblyTitle("Photon Server")]
 [assembly: AssemblyDescription("Primary service for Photon.")]

--- a/Plugins/Photon.Config/Properties/AssemblyInfo.cs
+++ b/Plugins/Photon.Config/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyVersion("0.0.2")]
+[assembly: AssemblyFileVersion("0.0.2")]
 
 [assembly: AssemblyTitle("Photon.Config")]
 [assembly: AssemblyDescription("App/Web configuration plugin for Photon.")]

--- a/Plugins/Photon.IIS/Properties/AssemblyInfo.cs
+++ b/Plugins/Photon.IIS/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyVersion("0.0.2")]
+[assembly: AssemblyFileVersion("0.0.2")]
 
 [assembly: AssemblyTitle("Photon.IIS")]
 [assembly: AssemblyDescription("IIS plugin for Photon.")]

--- a/Plugins/Photon.Nuget/NugetPackagePublisher.cs
+++ b/Plugins/Photon.Nuget/NugetPackagePublisher.cs
@@ -54,10 +54,6 @@ namespace Photon.NuGetPlugin
 
             cl.Pack(PackageDefinition, PackageDirectory);
 
-            //var packageFile = Path.Combine(PackageDirectory, $"{PackageId}.{Version}.nupkg");
-
-            //client.Pack(PackageDefinition, packageFile);
-
             var packageFilename = Directory
                 .GetFiles(PackageDirectory, $"{PackageId}.*.nupkg")
                 .FirstOrDefault();

--- a/Plugins/Photon.Nuget/Properties/AssemblyInfo.cs
+++ b/Plugins/Photon.Nuget/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyVersion("0.0.2")]
+[assembly: AssemblyFileVersion("0.0.2")]
 
 [assembly: AssemblyTitle("Photon.Nuget")]
 [assembly: AssemblyDescription("NuGet plugin for Photon.")]

--- a/Plugins/Photon.WindowsServices/Properties/AssemblyInfo.cs
+++ b/Plugins/Photon.WindowsServices/Properties/AssemblyInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyVersion("0.0.2")]
+[assembly: AssemblyFileVersion("0.0.2")]
 
 [assembly: AssemblyTitle("Photon.WindowsServices")]
 [assembly: AssemblyDescription("Windows Service plugin for Photon.")]


### PR DESCRIPTION
Catches the `HttpRequestException` to determine if a `409: Package already exists` error occurred, allowing the script to continue without throwing an exception.